### PR TITLE
Speedup future::poll_fn

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -30,13 +30,12 @@ use pin_utils::pin_mut;
 /// assert_eq!(next(&mut stream).await, None);
 /// # });
 /// ```
-pub async fn next<St>(stream: &mut St) -> Option<St::Item>
+pub fn next<'a, St>(mut stream: &'a mut St) -> impl Future<Output = Option<St::Item>> + 'a
 where
     St: Stream + Unpin,
 {
     use crate::future::poll_fn;
-    let future_next = poll_fn(|context| Pin::new(&mut *stream).poll_next(context));
-    future_next.await
+    poll_fn(move |context| Pin::new(&mut stream).poll_next(context))
 }
 
 /// Collect all of the values of this stream into a vector, returning a


### PR DESCRIPTION
This is a very questionable PR. Although it speeds up `future::poll_fn` by 50%, `stream::next` by 66%, `stream::collect` by 36%, I use the same style as futures-rs. I am not quite sure what is better: use `std::future::{from_generator, get_task_context}` or this style.

poll_fn's are very essential for combinators. They affect almost every function in this project.

```
future::poll_fn/futures time:   [256.97 ps 259.19 ps 262.00 ps]                                    
                        change: [-0.0236% +1.0588% +2.3550%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
future::poll_fn/async_combinators                                                                            
                        time:   [267.49 ps 274.56 ps 282.51 ps]
                        change: [-49.110% -48.386% -47.597%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  11 (11.00%) high mild
  5 (5.00%) high severe
stream::next/futures    time:   [810.23 ps 830.80 ps 860.39 ps]                                  
                        change: [+0.3469% +2.0130% +3.8131%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
stream::next/async_combinators                                                                             
                        time:   [767.31 ps 770.09 ps 773.47 ps]
                        change: [-66.524% -66.273% -66.012%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

stream::collect/futures time:   [1.5600 ns 1.5652 ns 1.5715 ns]                                     
                        change: [+2.0033% +2.7345% +3.5041%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
stream::collect/async_combinators                                                                             
                        time:   [2.5936 ns 2.6073 ns 2.6215 ns]
                        change: [-36.357% -36.020% -35.734%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```