### PR TITLE
Fix benches: actually poll futures in benches

### DIFF
--- a/benches/future.rs
+++ b/benches/future.rs
@@ -2,22 +2,24 @@ use criterion::*;
 use futures::executor;
 
 fn bench_ready(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("future::ready");
+    let mut group = c.benchmark_group("future::ready");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
-                black_box(futures::future::ready(42)).await
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
+                black_box(futures::future::ready(42).await);
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
-                black_box(futures_async_combinators::future::ready(42)).await
-            })
-        });
-
-        group.finish();
+        })
     });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
+                black_box(futures_async_combinators::future::ready(42).await);
+            })
+        })
+    });
+
+    group.finish();
 }
 
 fn bench_poll_fn(c: &mut Criterion) {
@@ -27,47 +29,51 @@ fn bench_poll_fn(c: &mut Criterion) {
         Poll::Ready(42)
     }
 
-    executor::block_on(async {
-        let mut group = c.benchmark_group("future::poll_fn");
+    let mut group = c.benchmark_group("future::poll_fn");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
-                black_box(futures::future::poll_fn(ret_42)).await
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
+                black_box(futures::future::poll_fn(ret_42).await);
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
-                black_box(futures_async_combinators::future::poll_fn(ret_42)).await
-            })
-        });
-
-        group.finish();
+        })
     });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
+                black_box(futures_async_combinators::future::poll_fn(ret_42)).await;
+            })
+        })
+    });
+
+    group.finish();
 }
 
 fn bench_map(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("future::map");
+    let mut group = c.benchmark_group("future::map");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::future::*;
                 let fut = ready(40);
                 let fut = fut.map(|x| x + 2);
-                black_box(fut).await
+                black_box(fut.await);
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
+        })
+    });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures_async_combinators::future::*;
                 let fut = ready(40);
                 let fut = map(fut, |x| x + 2);
-                black_box(fut).await
+                black_box(fut.await);
             })
-        });
-
-        group.finish();
+        })
     });
+
+    group.finish();
 }
 
 criterion_group!(benches, bench_ready, bench_poll_fn, bench_map);

--- a/benches/stream.rs
+++ b/benches/stream.rs
@@ -2,20 +2,22 @@ use criterion::*;
 use futures::executor;
 
 fn bench_stream_iter(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("stream::iter");
+    let mut group = c.benchmark_group("stream::iter");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::{iter, StreamExt};
                 let mut stream = iter(1..=1000);
                 while let Some(item) = stream.next().await {
                     black_box(item);
                 }
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
+        })
+    });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::StreamExt;
                 use futures_async_combinators::stream::iter;
                 let mut stream = iter(1..=1000);
@@ -23,27 +25,29 @@ fn bench_stream_iter(c: &mut Criterion) {
                     black_box(item);
                 }
             })
-        });
-
-        group.finish();
+        })
     });
+
+    group.finish();
 }
 
 fn bench_stream_next(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("stream::next");
+    let mut group = c.benchmark_group("stream::next");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::{iter, StreamExt};
                 let mut stream = iter(1..=1000);
                 while let Some(item) = stream.next().await {
                     black_box(item);
                 }
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
+        })
+    });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::iter;
                 use futures_async_combinators::stream::next;
                 let mut stream = iter(1..=1000);
@@ -51,92 +55,98 @@ fn bench_stream_next(c: &mut Criterion) {
                     black_box(item);
                 }
             })
-        });
-
-        group.finish();
+        })
     });
+
+    group.finish();
 }
 
 fn bench_stream_collect(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("stream::collect");
+    let mut group = c.benchmark_group("stream::collect");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::{iter, StreamExt};
                 let stream = iter(1..=1000);
                 let vec: Vec<_> = stream.collect().await;
-                black_box(vec)
+                black_box(vec);
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
+        })
+    });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::iter;
                 use futures_async_combinators::stream::collect;
                 let stream = iter(1..=1000);
                 let vec: Vec<_> = collect(stream).await;
-                black_box(vec)
+                black_box(vec);
             })
-        });
-
-        group.finish();
+        })
     });
+
+    group.finish();
 }
 
 fn bench_stream_map(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("stream::map");
+    let mut group = c.benchmark_group("stream::map");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::{iter, StreamExt};
                 let stream = iter(1..=1000);
                 let stream = stream.map(|x| x + 42);
                 let vec: Vec<_> = stream.collect().await;
-                black_box(vec)
+                black_box(vec);
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
+        })
+    });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::{iter, StreamExt};
                 use futures_async_combinators::stream::map;
                 let stream = iter(1..=1000);
                 let stream = map(stream, |x| x + 42);
                 let vec: Vec<_> = stream.collect().await;
-                black_box(vec)
+                black_box(vec);
             })
-        });
-
-        group.finish();
+        })
     });
+
+    group.finish();
 }
 
 fn bench_stream_fold(c: &mut Criterion) {
-    executor::block_on(async {
-        let mut group = c.benchmark_group("stream::fold");
+    let mut group = c.benchmark_group("stream::fold");
 
-        group.bench_function("futures", |b| {
-            b.iter(move || async {
+    group.bench_function("futures", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::{iter, StreamExt};
                 use futures_async_combinators::future::ready;
                 let stream = iter(1..=1000);
                 let acc = stream.fold(0, |acc, x| ready(acc + x));
-                black_box(acc).await
+                black_box(acc).await;
             })
-        });
-        group.bench_function("async_combinators", |b| {
-            b.iter(move || async {
+        })
+    });
+    group.bench_function("async_combinators", |b| {
+        b.iter(|| {
+            executor::block_on(async {
                 use futures::stream::iter;
                 use futures_async_combinators::future::ready;
                 use futures_async_combinators::stream::fold;
                 let stream = iter(1..=1000);
                 let acc = fold(stream, 0, |acc, x| ready(acc + x));
-                black_box(acc).await
+                black_box(acc).await;
             })
-        });
-
-        group.finish();
+        })
     });
+
+    group.finish();
 }
 
 criterion_group!(


### PR DESCRIPTION
Thanks to @jonas-schievink in https://github.com/rust-lang/rust/issues/70488#issuecomment-605523714

Comparison from 1.42.0-stable to 1.44.0-nightly:

```
     Running target/release/deps/future-a45d033e4c6a8a49
future::ready/futures   time:   [1.4139 ns 1.4214 ns 1.4284 ns]                                   
                        change: [-33.075% -32.463% -31.892%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) low mild
future::ready/async_combinators                                                                             
                        time:   [1.4258 ns 1.4343 ns 1.4430 ns]
                        change: [-74.031% -73.784% -73.538%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

future::poll_fn/futures time:   [923.22 ps 928.82 ps 934.70 ps]                                     
                        change: [-58.380% -57.936% -57.454%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
future::poll_fn/async_combinators                                                                             
                        time:   [1.0679 ns 1.0721 ns 1.0772 ns]
                        change: [-57.291% -55.216% -53.284%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

future::map/futures     time:   [1.4244 ns 1.4308 ns 1.4370 ns]                                 
                        change: [-34.310% -33.439% -32.391%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe
future::map/async_combinators                                                                             
                        time:   [2.1948 ns 2.1974 ns 2.2002 ns]
                        change: [-72.283% -71.937% -71.663%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

     Running target/release/deps/stream-ff2c5e87168d8d4c
stream::iter/futures    time:   [1.2016 us 1.2044 us 1.2073 us]                                  
                        change: [-43.719% -43.403% -43.102%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
stream::iter/async_combinators                                                                             
                        time:   [1.2012 us 1.2065 us 1.2132 us]
                        change: [-44.513% -43.887% -43.455%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

stream::next/futures    time:   [1.6517 us 1.6581 us 1.6681 us]                                  
                        change: [-21.251% -20.891% -20.513%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
stream::next/async_combinators                                                                             
                        time:   [1.6536 us 1.6570 us 1.6607 us]
                        change: [-22.210% -21.212% -19.984%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

stream::collect/futures time:   [3.8079 us 3.8200 us 3.8337 us]                                     
                        change: [-18.876% -18.374% -17.874%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
stream::collect/async_combinators                                                                             
                        time:   [4.6209 us 4.6394 us 4.6621 us]
                        change: [-13.893% -13.374% -12.815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

stream::map/futures     time:   [4.1590 us 4.1714 us 4.1870 us]                                 
                        change: [-5.0111% -4.2037% -3.4004%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
stream::map/async_combinators                                                                             
                        time:   [9.2230 us 9.2599 us 9.3010 us]
                        change: [-9.8141% -8.9312% -8.1937%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

stream::fold/futures    time:   [1.3115 us 1.3146 us 1.3179 us]                                  
                        change: [-10.420% -9.8719% -9.3034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
stream::fold/async_combinators                                                                             
                        time:   [2.2644 us 2.2704 us 2.2769 us]
                        change: [-49.459% -49.182% -48.925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
``` 